### PR TITLE
Add Github Action to automatically build binary files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Build Release
+
+on:
+  release:
+    types: [created]
+    
+permissions:
+  contents: read
+  
+jobs:
+  build-go-binary:
+    permissions:
+      contents: write  # for build-go-binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows]  
+        goarch: [amd64, arm64]
+        exclude:
+          - goarch: arm64
+            goos: windows
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Create version file
+        run: echo ${{ github.event.release.tag_name }} > VERSION
+      - name: Parallel build
+        uses: wangyoucao577/go-release-action@v1.30
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} 
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.18
+          pre_command: export CGO_ENABLED=0 && export GODEBUG=http2client=0
+          executable_compression: "upx -9"
+          md5sum: false
+          project_path: "./code"
+          binary_name: "start-feishubot"
+          extra_files: ./code/config.example.yaml


### PR DESCRIPTION
@Leizhenpeng i created a Github Action script, which can automatically build binaries when creating tags.
Like this example [seaweedfs tag 3.42](https://github.com/seaweedfs/seaweedfs/releases/tag/3.42) [ seaweedfs action](https://github.com/seaweedfs/seaweedfs/actions/runs/4100720133)