### PR TITLE
feat: Save the chatgpt context using sessionCache

### DIFF
--- a/code/handlers/group.go
+++ b/code/handlers/group.go
@@ -11,8 +11,8 @@ import (
 )
 
 type GroupMessageHandler struct {
-	userCache services.UserCacheInterface
-	msgCache  services.MsgCacheInterface
+	sessionCache services.SessionServiceCacheInterface
+	msgCache     services.MsgCacheInterface
 }
 
 func (p GroupMessageHandler) handle(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
@@ -22,9 +22,12 @@ func (p GroupMessageHandler) handle(ctx context.Context, event *larkim.P2Message
 	}
 	content := event.Event.Message.Content
 	msgId := event.Event.Message.MessageId
-	sender := event.Event.Sender
-	openId := sender.SenderId.OpenId
+	rootId := event.Event.Message.RootId
 	chatId := event.Event.Message.ChatId
+	sessionId := rootId
+	if sessionId == nil || *sessionId == "" {
+		sessionId = msgId
+	}
 
 	if p.msgCache.IfProcessed(*msgId) {
 		fmt.Println("msgId", *msgId, "processed")
@@ -39,12 +42,12 @@ func (p GroupMessageHandler) handle(ctx context.Context, event *larkim.P2Message
 	}
 
 	if qParsed == "/clear" || qParsed == "清除" {
-		p.userCache.Clear(*openId)
+		p.sessionCache.Clear(*sessionId)
 		sendMsg(ctx, "🤖️：AI机器人已清除记忆", chatId)
 		return nil
 	}
 
-	msg := p.userCache.Get(*openId)
+	msg := p.sessionCache.Get(*sessionId)
 	msg = append(msg, services.Messages{
 		Role: "user", Content: qParsed,
 	})
@@ -54,7 +57,7 @@ func (p GroupMessageHandler) handle(ctx context.Context, event *larkim.P2Message
 		return nil
 	}
 	msg = append(msg, completions)
-	p.userCache.Set(*openId, msg)
+	p.sessionCache.Set(*sessionId, msg)
 	err = replyMsg(ctx, completions.Content, msgId)
 	if err != nil {
 		replyMsg(ctx, fmt.Sprintf("🤖️：消息机器人摆烂了，请稍后再试～\n错误信息: %v", err), msgId)
@@ -68,8 +71,8 @@ var _ MessageHandlerInterface = (*PersonalMessageHandler)(nil)
 
 func NewGroupMessageHandler() MessageHandlerInterface {
 	return &GroupMessageHandler{
-		userCache: services.GetUserCache(),
-		msgCache:  services.GetMsgCache(),
+		sessionCache: services.GetSessionCache(),
+		msgCache:     services.GetMsgCache(),
 	}
 }
 

--- a/code/services/sessionCache.go
+++ b/code/services/sessionCache.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+type SessionService struct {
+	cache *cache.Cache
+}
+
+var sessionServices *SessionService
+
+func (u SessionService) Get(sessionId string) (msg []Messages) {
+	// 获取用户的会话上下文
+	sessionContext, ok := u.cache.Get(sessionId)
+	if !ok {
+		return msg
+	}
+	return sessionContext.([]Messages)
+}
+
+func (u SessionService) Set(sessionId string, msg []Messages) {
+	maxLength := 4096
+	maxCacheTime := time.Hour * 12
+
+	//限制对话上下文长度
+	for getStrPoolTotalLength(msg) > maxLength {
+		msg = msg[2:]
+	}
+	u.cache.Set(sessionId, msg, maxCacheTime)
+}
+
+func (u SessionService) Clear(sessionId string) bool {
+	u.cache.Delete(sessionId)
+	return true
+}
+
+type SessionServiceCacheInterface interface {
+	Get(sessionId string) []Messages
+	Set(sessionId string, msg []Messages)
+	Clear(sessionId string) bool
+}
+
+func GetSessionCache() SessionServiceCacheInterface {
+	if sessionServices == nil {
+		sessionServices = &SessionService{cache: cache.New(time.Hour*12, time.Hour*1)}
+	}
+	return sessionServices
+}

--- a/code/services/userCache.go
+++ b/code/services/userCache.go
@@ -27,7 +27,7 @@ func (u UserService) Set(userId string, msg []Messages) {
 	//如果满了，删除最早的一个
 	//如果没有满，直接添加
 	maxCache := 16
-	maxLength := 2048
+	maxLength := 4096
 	maxCacheTime := time.Minute * 30
 
 	if len(msg) == maxCache {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module leizhenpeng/feishu-chatgpt
-
-go 1.18


### PR DESCRIPTION
模仿 chatgpt 每个话题可以创建一个 chat.
对应飞书里面的一个会话上下文.

<img width="999" alt="截屏2023-03-03 03 47 02" src="https://user-images.githubusercontent.com/17420327/222536286-e8d49c4e-1d96-4250-bb0c-c4345b4c638f.png">

<img width="1261" alt="截屏2023-03-03 03 48 49" src="https://user-images.githubusercontent.com/17420327/222536846-77598f7f-dec8-4c68-b6dc-a31324b965ee.png">

