### PR TITLE
feat: add entrypoint.sh to let docker can use environment to set config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ FROM alpine:latest
 WORKDIR /dist
 
 RUN apk add --no-cache bash
-COPY --from=golang /build/config.yaml /dist/config.yaml
+COPY --from=golang /build/config.example.yaml /dist/config.yaml
 COPY --from=golang /build/feishu_chatgpt /dist
+ADD entrypoint.sh /dist/entrypoint.sh
 
 EXPOSE 9000
-ENTRYPOINT ["/dist/feishu_chatgpt"]
+CMD /dist/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+APP_ID=${APP_ID:-""}
+APP_SECRET=${APP_SECRET:-""}
+APP_ENCRYPT_KEY=${APP_ENCRYPT_KEY:-""}
+APP_VERIFICATION_TOKEN=${APP_VERIFICATION_TOKEN:-""}
+BOT_NAME=${BOT_NAME:-""}
+OPENAI_KEY=${OPENAI_KEY:-""}
+CONFIG_PATH=${CONFIG_PATH:-"config.yaml"}
+
+
+# modify content in config.yaml
+if [ "$APP_ID" != "" ] ; then
+    sed -i "2c   APP_ID: $APP_ID" $CONFIG_PATH
+else
+    echo -e "\033[31m[Warning] You need to set APP_ID before running!\033[0m"
+fi
+
+if [ "$APP_SECRET" != "" ] ; then
+    sed -i "3c   APP_SECRET: $APP_SECRET" $CONFIG_PATH
+else
+    echo -e "\033[31m[Warning] You need to set APP_SECRET before running!\033[0m"
+fi
+
+if [ "$APP_ENCRYPT_KEY" != "" ] ; then
+    sed -i "4c   APP_ENCRYPT_KEY: $APP_ENCRYPT_KEY" $CONFIG_PATH
+fi
+
+if [ "$APP_VERIFICATION_TOKEN" != "" ] ; then
+    sed -i "5c   APP_VERIFICATION_TOKEN: $APP_VERIFICATION_TOKEN" $CONFIG_PATH
+else
+    echo -e "\033[31m[Warning] You need to set APP_VERIFICATION_TOKEN before running!\033[0m"
+fi
+
+if [ "$BOT_NAME" != "" ] ; then
+    sed -i "7c   BOT_NAME: $BOT_NAME" $CONFIG_PATH
+fi
+
+
+if [ "$OPENAI_KEY" != "" ] ; then
+    sed -i "9c   OPENAI_KEY: $OPENAI_KEY" $CONFIG_PATH
+else
+    echo -e "\033[31m[Warning] You need to set OPENAI_KEY before running!\033[0m"
+fi
+
+/dist/feishu_chatgpt

--- a/readme.md
+++ b/readme.md
@@ -113,28 +113,27 @@ s deploy
 <br>
 
 ``` bash
-# 配置config.yaml
-mv config.example.yaml config.yaml
-# 构建运行
-cd ..
 docker build -t feishu-chatgpt:latest .
-docker run -d --name feishu-chatgpt -p 9000:9000 feishu-chatgpt:latest
+docker run -d --name feishu-chatgpt -p 9000:9000 \
+--env APP_ID=xxx \
+--env APP_SECRET=xxx \
+--env APP_VERIFICATION_TOKEN=xxx \
+--env OPENAI_KEY=sk-xxx \
+feishu-chatgpt:latest
 ```
 ------------
 小白简易化docker部署版
 
 ``` bash
 docker地址:https://hub.docker.com/r/w779945/feishu-chatgpt3.5
+docker地址: https://hub.docker.com/r/cfxks1989/feishu-chatgpt
 
-docker run -d --restart=always --name feishu-chatgpt2 -p 9500:9000 -v /etc/localtime:/etc/localtim:ro w779945/feishu-chatgpt3.5:latest
-
-docker exec -it feishu-chatgpt2 bash #进入容器
-
-vi config.yaml #修改参数
-
-exit #退出容器
-
-docker restart feishu-chatgpt2 #重启容器
+docker run -d --restart=always --name feishu-chatgpt2 -p 9500:9000 -v /etc/localtime:/etc/localtim:ro  \
+--env APP_ID=xxx \
+--env APP_SECRET=xxx \
+--env APP_VERIFICATION_TOKEN=xxx \
+--env OPENAI_KEY=sk-xxx \
+cfxks1989/feishu-chatgpt:latest
 
 最后回调地址是: http://IP:9500/webhook/event
 


### PR DESCRIPTION
现有版本的docker不支持通过传入环境变量的方式启动服务，就需要启动服务后进入容器内修改或者是将配置文件从外部挂载进去。
- 在Dockerfile直接从config.example.yaml 复制文件，不需要减少了目前需要前置mv动作。
- 版本增加了entrypoint.sh 增加了环境变量替换配置文件功能。可以通过环境变量来修改相应参数。进一步简化使用方法。
