### PR TITLE
fix: null pointer generated when import cert file

### DIFF
--- a/code/initialization/gin.go
+++ b/code/initialization/gin.go
@@ -2,11 +2,13 @@ package initialization
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 func loadCertificate(config Config) (cert tls.Certificate, err error) {
@@ -14,13 +16,24 @@ func loadCertificate(config Config) (cert tls.Certificate, err error) {
 	if err != nil {
 		return cert, fmt.Errorf("failed to load certificate: %v", err)
 	}
+
 	// check certificate expiry
+	if len(cert.Certificate) == 0 {
+		return cert, fmt.Errorf("no certificates found in %s", config.CertFile)
+	}
+	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return cert, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+	cert.Leaf = parsedCert
 	certExpiry := cert.Leaf.NotAfter
 	if certExpiry.Before(time.Now()) {
 		return cert, fmt.Errorf("certificate expired on %v", certExpiry)
 	}
+
 	return cert, nil
 }
+
 func startHTTPServer(config Config, r *gin.Engine) (err error) {
 	log.Printf("http server started: http://localhost:%d/webhook/event\n", config.HttpPort)
 	err = r.Run(fmt.Sprintf(":%d", config.HttpPort))


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
解决cert.leaf :*crypto/x509.certificate nil时产生的空指针报错：
检查了证书列表是否为空，如果为空则返回错误。然后将证书列表中的第一个证书解析成x509.Certificate，并将其设置为cert.Leaf，这样避免了空指针错误。
