### PR TITLE
chore: fix Dockerfile for ARM arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GO111MODULE=on \
 WORKDIR /build
 ADD /code /build
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w -s' -o feishu_chatgpt
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s' -o feishu_chatgpt
 
 FROM alpine:latest
 


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述

The Dockerfile is used for both AMD64 and ARM64, but the binary is AMD64 even for the ARM64 images before this PR.

![image](https://user-images.githubusercontent.com/3183039/227700837-250cb201-8647-4789-a750-cde432098ccb.png)


## 相关问题
- [问题编号]（问题链接）
