### PR TITLE
Feat: Support azure openai

### DIFF
--- a/code/config.example.yaml
+++ b/code/config.example.yaml
@@ -17,3 +17,11 @@ KEY_FILE: key.pem
 API_URL: https://api.openai.com
 # 代理设置, 例如 "http://127.0.0.1:7890", ""代表不使用代理
 HTTP_PROXY: ""
+
+# AZURE OPENAI
+AZURE_ON: true # set to true to use Azure rather than OpenAI
+AZURE_API_VERSION: 2023-03-15-preview # 2023-03-15-preview or 2022-12-01 refer https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions
+AZURE_RESOURCE_NAME: xxxx   # you can find in endpoint url. Usually looks like https://{RESOURCE_NAME}.openai.azure.com
+AZURE_DEPLOYMENT_NAME: xxxx # usually looks like ...openai.azure.com/openai/deployments/{DEPLOYMENT_NAME}/chat/completions.
+AZURE_OPENAI_TOKEN: xxxx  # Authentication key. We can use Azure Active Directory Authentication(TBD).
+

--- a/code/handlers/event_audio_action.go
+++ b/code/handlers/event_audio_action.go
@@ -13,6 +13,11 @@ type AudioAction struct { /*语音*/
 }
 
 func (*AudioAction) Execute(a *ActionInfo) bool {
+	check := AzureModeCheck(a)
+	if !check {
+		return true
+	}
+
 	// 只有私聊才解析语音,其他不解析
 	if a.info.handlerType != UserHandler {
 		return true

--- a/code/handlers/event_pic_action.go
+++ b/code/handlers/event_pic_action.go
@@ -15,6 +15,10 @@ type PicAction struct { /*图片*/
 }
 
 func (*PicAction) Execute(a *ActionInfo) bool {
+	check := AzureModeCheck(a)
+	if !check {
+		return true
+	}
 	// 开启图片创作模式
 	if _, foundPic := utils.EitherTrimEqual(a.info.qParsed,
 		"/picture", "图片创作"); foundPic {

--- a/code/handlers/handler.go
+++ b/code/handlers/handler.go
@@ -125,3 +125,11 @@ func (m MessageHandler) judgeIfMentionMe(mention []*larkim.
 	}
 	return *mention[0].Name == m.config.FeishuBotName
 }
+
+func AzureModeCheck(a *ActionInfo) bool {
+	if a.handler.config.AzureOn {
+		//sendMsg(*a.ctx, "Azure Openai 接口下，暂不支持此功能", a.info.chatId)
+		return false
+	}
+	return true
+}

--- a/code/initialization/config.go
+++ b/code/initialization/config.go
@@ -23,6 +23,11 @@ type Config struct {
 	KeyFile                    string
 	OpenaiApiUrl               string
 	HttpProxy                  string
+	AzureOn                    bool
+	AzureApiVersion            string
+	AzureDeploymentName        string
+	AzureResourceName          string
+	AzureOpenaiToken           string
 }
 
 func LoadConfig(cfg string) *Config {
@@ -49,6 +54,11 @@ func LoadConfig(cfg string) *Config {
 		KeyFile:                    getViperStringValue("KEY_FILE", "key.pem"),
 		OpenaiApiUrl:               getViperStringValue("API_URL", "https://api.openai.com"),
 		HttpProxy:                  getViperStringValue("HTTP_PROXY", ""),
+		AzureOn:                    getViperBoolValue("AZURE_ON", false),
+		AzureApiVersion:            getViperStringValue("AZURE_API_VERSION", "2023-03-15-preview"),
+		AzureDeploymentName:        getViperStringValue("AZURE_DEPLOYMENT_NAME", ""),
+		AzureResourceName:          getViperStringValue("AZURE_RESOURCE_NAME", ""),
+		AzureOpenaiToken:           getViperStringValue("AZURE_OPENAI_TOKEN", ""),
 	}
 
 	return config

--- a/code/services/openai/audio.go
+++ b/code/services/openai/audio.go
@@ -47,7 +47,7 @@ func audioMultipartForm(request AudioToTextRequestBody, w *multipart.Writer) err
 	return nil
 }
 
-func (gpt ChatGPT) AudioToText(audio string) (string, error) {
+func (gpt *ChatGPT) AudioToText(audio string) (string, error) {
 	requestBody := AudioToTextRequestBody{
 		File:           audio,
 		Model:          "whisper-1",

--- a/code/services/openai/common.go
+++ b/code/services/openai/common.go
@@ -110,10 +110,10 @@ func (gpt *ChatGPT) doAPIRequestWithRetry(url, method string,
 	if bodyType == formVoiceDataBody || bodyType == formPictureDataBody {
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 	}
-	if gpt.Platform == Azure {
-		req.Header.Set("api-key", gpt.AzureConfig.ApiToken)
-	} else {
+	if gpt.Platform == OpenAI {
 		req.Header.Set("Authorization", "Bearer "+api.Key)
+	} else {
+		req.Header.Set("api-key", gpt.AzureConfig.ApiToken)
 	}
 
 	var response *http.Response
@@ -188,7 +188,13 @@ func (gpt *ChatGPT) sendRequestWithBodyType(link, method string,
 }
 
 func NewChatGPT(config initialization.Config) *ChatGPT {
-	lb := loadbalancer.NewLoadBalancer(config.OpenaiApiKeys)
+	var lb *loadbalancer.LoadBalancer
+	if config.AzureOn {
+		keys := []string{config.AzureOpenaiToken}
+		lb = loadbalancer.NewLoadBalancer(keys)
+	} else {
+		lb = loadbalancer.NewLoadBalancer(config.OpenaiApiKeys)
+	}
 	platform := OpenAI
 
 	if config.AzureOn {

--- a/code/services/openai/common.go
+++ b/code/services/openai/common.go
@@ -18,7 +18,7 @@ import (
 type PlatForm string
 
 const (
-	AzureApiUrlV1 = ".openai.azure.com/openai/deployments/"
+	AzureApiUrlV1 = "openai.azure.com/openai/deployments/"
 )
 const (
 	OpenAI PlatForm = "openai"
@@ -50,7 +50,8 @@ const (
 	nilBody
 )
 
-func (gpt ChatGPT) doAPIRequestWithRetry(url, method string, bodyType requestBodyType,
+func (gpt *ChatGPT) doAPIRequestWithRetry(url, method string,
+	bodyType requestBodyType,
 	requestBody interface{}, responseBody interface{}, client *http.Client, maxRetries int) error {
 	var api *loadbalancer.API
 	var requestBodyData []byte
@@ -155,7 +156,8 @@ func (gpt ChatGPT) doAPIRequestWithRetry(url, method string, bodyType requestBod
 	return nil
 }
 
-func (gpt ChatGPT) sendRequestWithBodyType(link, method string, bodyType requestBodyType,
+func (gpt *ChatGPT) sendRequestWithBodyType(link, method string,
+	bodyType requestBodyType,
 	requestBody interface{}, responseBody interface{}) error {
 	var err error
 	client := &http.Client{Timeout: 110 * time.Second}
@@ -202,4 +204,17 @@ func NewChatGPT(config initialization.Config) *ChatGPT {
 			ApiVersion:     config.AzureApiVersion,
 		},
 	}
+}
+
+func (gpt *ChatGPT) FullUrl(suffix string) string {
+	var url string
+	switch gpt.Platform {
+	case Azure:
+		url = fmt.Sprintf("https://%s.%s%s%s?api-version=%s",
+			gpt.AzureConfig.ResourceName, gpt.AzureConfig.BaseURL,
+			gpt.AzureConfig.DeploymentName, suffix, gpt.AzureConfig.ApiVersion)
+	default:
+		url = fmt.Sprintf("%s/v1%s", gpt.ApiUrl, suffix)
+	}
+	return url
 }

--- a/code/services/openai/gpt3.go
+++ b/code/services/openai/gpt3.go
@@ -41,7 +41,8 @@ type ChatGPTRequestBody struct {
 	PresencePenalty  int        `json:"presence_penalty"`
 }
 
-func (gpt ChatGPT) Completions(msg []Messages) (resp Messages, err error) {
+func (gpt *ChatGPT) Completions(msg []Messages) (resp Messages,
+	err error) {
 	requestBody := ChatGPTRequestBody{
 		Model:            engine,
 		Messages:         msg,
@@ -53,9 +54,7 @@ func (gpt ChatGPT) Completions(msg []Messages) (resp Messages, err error) {
 	}
 	gptResponseBody := &ChatGPTResponseBody{}
 	err = gpt.sendRequestWithBodyType(gpt.ApiUrl+"/v1/chat/completions", "POST",
-		jsonBody,
-		requestBody, gptResponseBody)
-
+		jsonBody, requestBody, gptResponseBody)
 	if err == nil && len(gptResponseBody.Choices) > 0 {
 		resp = gptResponseBody.Choices[0].Message
 	} else {

--- a/code/services/openai/gpt3.go
+++ b/code/services/openai/gpt3.go
@@ -53,8 +53,12 @@ func (gpt *ChatGPT) Completions(msg []Messages) (resp Messages,
 		PresencePenalty:  0,
 	}
 	gptResponseBody := &ChatGPTResponseBody{}
-	err = gpt.sendRequestWithBodyType(gpt.ApiUrl+"/v1/chat/completions", "POST",
-		jsonBody, requestBody, gptResponseBody)
+	url := gpt.FullUrl("chat/completions")
+	//fmt.Println(url)
+	if url == "" {
+		return resp, errors.New("无法获取openai请求地址")
+	}
+	err = gpt.sendRequestWithBodyType(url, "POST", jsonBody, requestBody, gptResponseBody)
 	if err == nil && len(gptResponseBody.Choices) > 0 {
 		resp = gptResponseBody.Choices[0].Message
 	} else {

--- a/code/services/openai/gpt3_test.go
+++ b/code/services/openai/gpt3_test.go
@@ -108,6 +108,7 @@ func TestVariateOneImageWithJpg(t *testing.T) {
 	}
 }
 
+// 余额接口已经被废弃
 func TestChatGPT_GetBalance(t *testing.T) {
 	config := initialization.LoadConfig("../../config.yaml")
 	gpt := NewChatGPT(*config)

--- a/code/services/openai/picture.go
+++ b/code/services/openai/picture.go
@@ -32,7 +32,8 @@ type ImageVariantRequestBody struct {
 	ResponseFormat string `json:"response_format"`
 }
 
-func (gpt ChatGPT) GenerateImage(prompt string, size string, n int) ([]string, error) {
+func (gpt *ChatGPT) GenerateImage(prompt string, size string,
+	n int) ([]string, error) {
 	requestBody := ImageGenerationRequestBody{
 		Prompt:         prompt,
 		N:              n,
@@ -55,7 +56,8 @@ func (gpt ChatGPT) GenerateImage(prompt string, size string, n int) ([]string, e
 	return b64Pool, nil
 }
 
-func (gpt ChatGPT) GenerateOneImage(prompt string, size string) (string, error) {
+func (gpt *ChatGPT) GenerateOneImage(prompt string,
+	size string) (string, error) {
 	b64s, err := gpt.GenerateImage(prompt, size, 1)
 	if err != nil {
 		return "", err
@@ -63,11 +65,13 @@ func (gpt ChatGPT) GenerateOneImage(prompt string, size string) (string, error) 
 	return b64s[0], nil
 }
 
-func (gpt ChatGPT) GenerateOneImageWithDefaultSize(prompt string) (string, error) {
+func (gpt *ChatGPT) GenerateOneImageWithDefaultSize(
+	prompt string) (string, error) {
 	return gpt.GenerateOneImage(prompt, "512x512")
 }
 
-func (gpt ChatGPT) GenerateImageVariation(images string, size string, n int) ([]string, error) {
+func (gpt *ChatGPT) GenerateImageVariation(images string,
+	size string, n int) ([]string, error) {
 	requestBody := ImageVariantRequestBody{
 		Image:          images,
 		N:              n,
@@ -90,7 +94,8 @@ func (gpt ChatGPT) GenerateImageVariation(images string, size string, n int) ([]
 	return b64Pool, nil
 }
 
-func (gpt ChatGPT) GenerateOneImageVariation(images string, size string) (string, error) {
+func (gpt *ChatGPT) GenerateOneImageVariation(images string,
+	size string) (string, error) {
 	b64s, err := gpt.GenerateImageVariation(images, size, 1)
 	if err != nil {
 		return "", err

--- a/readme.md
+++ b/readme.md
@@ -290,7 +290,7 @@ dockerproxy.com/leizhenpeng/feishu-chatgpt:latest
 卡片回调地址: http://IP:9000/webhook/card
 
 把它填入飞书后台
-<br>
+
 --- 
 
 部署azure版本

--- a/readme.md
+++ b/readme.md
@@ -291,6 +291,34 @@ dockerproxy.com/leizhenpeng/feishu-chatgpt:latest
 
 把它填入飞书后台
 <br>
+--- 
+
+部署azure版本
+
+```bash
+docker build -t feishu-chatgpt:latest .
+docker run -d --name feishu-chatgpt -p 9000:9000 \
+--env APP_ID=xxx \
+--env APP_SECRET=xxx \
+--env APP_ENCRYPT_KEY=xxx \
+--env APP_VERIFICATION_TOKEN=xxx \
+--env BOT_NAME=chatGpt \
+--env AZURE_ON=true \
+--env AZURE_API_VERSION=xxx \
+--env AZURE_RESOURCE_NAME=xxx \
+--env AZURE_DEPLOYMENT_NAME=xxx \
+--env AZURE_OPENAI_TOKEN=xxx \
+feishu-chatgpt:latest
+```
+
+注意:
+
+- `BOT_NAME` 为飞书机器人名称，例如 `chatGpt`
+- `AZURE_ON` 为是否使用azure ,请填写 `true`
+- `AZURE_API_VERSION` 为azure api版本 例如 `2023-03-15-preview`
+- `AZURE_RESOURCE_NAME` 为azure 资源名称 类似 `https://{AZURE_RESOURCE_NAME}.openai.azure.com`
+- `AZURE_DEPLOYMENT_NAME` 为azure 部署名称 类似 `https://{AZURE_RESOURCE_NAME}.openai.azure.com/deployments/{AZURE_DEPLOYMENT_NAME}/chat/completions`
+- `AZURE_OPENAI_TOKEN` 为azure openai token
 
 </details>
 


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
支持azure 的openai接口
参见：https://azure.microsoft.com/zh-cn/pricing/details/cognitive-services/openai-service/
### 增加下面环境变量
```yaml
# set to true to use Azure rather than OpenAI
AZURE_ON: true 
# 2023-03-15-preview or 2022-12-01 
AZURE_API_VERSION: 2023-03-15-preview 
# you can find in endpoint url. Usually looks like https://{RESOURCE_NAME}.openai.azure.com
AZURE_RESOURCE_NAME: xxxx   
# usually looks like ...openai.azure.com/openai/deployments/{DEPLOYMENT_NAME}/chat/completions.
AZURE_DEPLOYMENT_NAME: xxxx 
# Authentication key. Use Azure Active Directory Authentication(TBD).
AZURE_OPENAI_TOKEN: xxxx  

```

### 例如docker部署
```
docker build -t feishu-chatgpt:latest .
docker run -d --name feishu-chatgpt -p 9000:9000 \
--env APP_ID=xxx \
--env APP_SECRET=xxx \
--env APP_ENCRYPT_KEY=xxx \
--env APP_VERIFICATION_TOKEN=xxx \
--env BOT_NAME=chatGpt \
--env AZURE_ON=true \
--env AZURE_API_VERSION=xxx \
--env AZURE_RESOURCE_NAME=xxx \
--env AZURE_DEPLOYMENT_NAME=xxx \
--env AZURE_OPENAI_TOKEN=xxx \
feishu-chatgpt:latest
```

- `BOT_NAME` 为飞书机器人名称，例如 `chatGpt`
- `AZURE_ON` 为是否使用azure ,请填写 `true`
- `AZURE_API_VERSION` 为azure api版本 例如 `2023-03-15-preview`
- `AZURE_RESOURCE_NAME` 为azure 资源名称 类似 `https://{AZURE_RESOURCE_NAME}.openai.azure.com`
- `AZURE_DEPLOYMENT_NAME` 为azure 部署名称 类似 `https://{AZURE_RESOURCE_NAME}.openai.azure.com/deployments/{AZURE_DEPLOYMENT_NAME}/chat/completions`
- `AZURE_OPENAI_TOKEN` 为azure openai token

### 注意
在azure模式下，
- 自动关闭图片创作和语音交互功能
- `OPENAI_KEY`环境变量将自动失效

## 相关问题
- #107 
