### PR TITLE
fix: #178 goroutine nil pointer causes the service crash

### DIFF
--- a/code/handlers/msg.go
+++ b/code/handlers/msg.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"errors"
 	"github.com/google/uuid"
 	larkcard "github.com/larksuite/oapi-sdk-go/v3/card"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
@@ -67,7 +68,7 @@ func replyCard(ctx context.Context,
 	// 服务端错误处理
 	if !resp.Success() {
 		fmt.Println(resp.Code, resp.Msg, resp.RequestId())
-		return err
+		return errors.New(resp.Msg)
 	}
 	return nil
 }
@@ -432,7 +433,7 @@ func replyMsg(ctx context.Context, msg string, msgId *string) error {
 	// 服务端错误处理
 	if !resp.Success() {
 		fmt.Println(resp.Code, resp.Msg, resp.RequestId())
-		return err
+		return errors.New(resp.Msg)
 	}
 	return nil
 }
@@ -461,7 +462,7 @@ func uploadImage(base64Str string) (*string, error) {
 	// 服务端错误处理
 	if !resp.Success() {
 		fmt.Println(resp.Code, resp.Msg, resp.RequestId())
-		return nil, err
+		return nil, errors.New(resp.Msg)
 	}
 	return resp.Data.ImageKey, nil
 }
@@ -495,7 +496,7 @@ func replyImage(ctx context.Context, ImageKey *string,
 	// 服务端错误处理
 	if !resp.Success() {
 		fmt.Println(resp.Code, resp.Msg, resp.RequestId())
-		return err
+		return errors.New(resp.Msg)
 	}
 	return nil
 
@@ -580,7 +581,7 @@ func sendMsg(ctx context.Context, msg string, chatId *string) error {
 	// 服务端错误处理
 	if !resp.Success() {
 		fmt.Println(resp.Code, resp.Msg, resp.RequestId())
-		return err
+		return errors.New(resp.Msg)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [fix]。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
[fix]修复【服务端错误处理】返回空err的bug

简述：当前【服务端错误处理】，返回的err为空指针，导致调用方根据err判断时，误认为成功，从而在执行一些操作时，有几率导致panic，以至于服务崩溃，具体故障如下所示


## 相关问题
- #178 
